### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Run tests and upload coverage to codecov
 on: 
   push


### PR DESCRIPTION
Potential fix for [https://github.com/drawks/gearhulk/security/code-scanning/1](https://github.com/drawks/gearhulk/security/code-scanning/1)

To fix the error, we need to add the `permissions` block to the workflow file. This block will specify the least privileges required for the workflow to execute its tasks successfully. Based on the provided workflow, the following permissions are needed:
- `contents: read` for checking out the repository code.
- `contents: write` for uploading coverage results to Codecov (if required).

The permissions can be added at the root of the workflow, applying to all jobs, or within the specific job (`test`) block. For simplicity and clarity, we'll add the permissions at the root level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
